### PR TITLE
Bump types-docutils from 0.21.0.20250514 to 0.21.0.20250516

Bumps [types-docutils](https://github.com/typeshed-internal/stub_uploader) from 0.21.0.20250514 to 0.21.0.20250516.
- [Commits](https://github.com/typeshed-internal/stub_uploader/commits)

---
updated-dependencies:
- dependency-name: types-docutils
  dependency-version: 0.21.0.20250516
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ lint = [
     "sphinx-lint>=0.9",
     "types-colorama==0.4.15.20240311",
     "types-defusedxml==0.7.0.20250516",
-    "types-docutils==0.21.0.20250514",
+    "types-docutils==0.21.0.20250516",
     "types-Pillow==10.2.0.20240822",
     "types-Pygments==2.19.0.20250516",
     "types-requests==2.32.0.20250515",  # align with requests
@@ -165,7 +165,7 @@ type-stubs = [
     # align with versions used elsewhere
     "types-colorama==0.4.15.20240311",
     "types-defusedxml==0.7.0.20250516",
-    "types-docutils==0.21.0.20250514",
+    "types-docutils==0.21.0.20250516",
     "types-Pillow==10.2.0.20240822",
     "types-Pygments==2.19.0.20250516",
     "types-requests==2.32.0.20250515",


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->ROM2024-siber

- <...>
- <...>
- <...>
